### PR TITLE
Change the visibility of npm package

### DIFF
--- a/.changeset/grumpy-weeks-wink.md
+++ b/.changeset/grumpy-weeks-wink.md
@@ -1,0 +1,5 @@
+---
+"@segment/edge-sdk": patch
+---
+
+change the visibility

--- a/packages/edge-sdk/package.json
+++ b/packages/edge-sdk/package.json
@@ -9,9 +9,6 @@
   "files": [
     "dist/**"
   ],
-  "publishConfig": {
-    "access": "restricted"
-  },
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts",


### PR DESCRIPTION
Looks like since last publish, the visibility was flipped back to restricted. Updating the vis, so it won't happen after each publish. 