### PR TITLE
rename packages for security purposes, fix lint errors

### DIFF
--- a/.changeset/nasty-starfishes-destroy.md
+++ b/.changeset/nasty-starfishes-destroy.md
@@ -1,0 +1,5 @@
+---
+"@segment/edge-sdk": patch
+---
+
+Fix lint errors

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   root: true,
-  // This tells ESLint to load the config from the package `eslint-config-edge-sdk`
+  // This tells ESLint to load the config from the package `@segment/eslint-config-edge-sdk`
   extends: ["edge-sdk"],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  root: true,
-  // This tells ESLint to load the config from the package `@segment/eslint-config-edge-sdk`
-  extends: ["@segment/edge-sdk"],
-};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   root: true,
   // This tells ESLint to load the config from the package `@segment/eslint-config-edge-sdk`
-  extends: ["edge-sdk"],
+  extends: ["@segment/edge-sdk"],
 };

--- a/examples/cloudflare_example/package.json
+++ b/examples/cloudflare_example/package.json
@@ -6,8 +6,8 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.16.0",
+    "@segment/eslint-config-edge-sdk": "*",
     "@segment/tsconfig-edge-sdk": "*",
-    "eslint-config-edge-sdk": "*",
     "typescript": "^4.8.3",
     "wrangler": "2.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.22.0",
-    "eslint-config-edge-sdk": "*",
+    "@segment/eslint-config-edge-sdk": "*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   },

--- a/packages/edge-sdk/.eslintrc.js
+++ b/packages/edge-sdk/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["edge-sdk"],
+  extends: ["@segment/edge-sdk"],
 };

--- a/packages/edge-sdk/.eslintrc.js
+++ b/packages/edge-sdk/.eslintrc.js
@@ -1,4 +1,3 @@
 module.exports = {
-  root: true,
   extends: ["@segment/edge-sdk"],
 };

--- a/packages/edge-sdk/package.json
+++ b/packages/edge-sdk/package.json
@@ -12,23 +12,23 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
-    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts*",
     "clean": "rm -rf .turbo && rm -rf dist",
     "postversion": "sh scripts/version.sh",
     "test": "jest"
   },
   "jest": {
-    "preset": "jest-presets/jest/cf"
+    "preset": "@segment/jest-presets/jest/cf"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.16.0",
+    "@segment/eslint-config-edge-sdk": "*",
+    "@segment/jest-presets": "*",
     "@segment/tsconfig-edge-sdk": "*",
     "@types/jest": "^29.0.3",
     "@types/uuid": "^8.3.4",
     "eslint": "^7.32.0",
-    "eslint-config-edge-sdk": "*",
     "jest": "^29.0.3",
-    "jest-presets": "*",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"
   },

--- a/packages/edge-sdk/src/cookies.ts
+++ b/packages/edge-sdk/src/cookies.ts
@@ -118,7 +118,7 @@ export const extractIdFromPayload: HandlerFunction = async (
   response,
   context
 ) => {
-  let body: { [key: string]: any } = await request.json();
+  const body: { [key: string]: any } = await request.json();
   const newContext = { ...context };
 
   if (body.userId) {

--- a/packages/edge-sdk/src/personas.ts
+++ b/packages/edge-sdk/src/personas.ts
@@ -54,7 +54,7 @@ export const handlePersonasWebhook: HandlerFunction = async (
     ];
   }
 
-  let event = (await request.json()) as PersonasWebhookPayload;
+  const event = (await request.json()) as PersonasWebhookPayload;
 
   if (event.type !== "identify") {
     context.logger.log("debug", "Ignoring incoming webhook, not an identify", {

--- a/packages/eslint-config-edge-sdk/package.json
+++ b/packages/eslint-config-edge-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-edge-sdk",
+  "name": "@segment/eslint-config-edge-sdk",
   "version": "0.0.0",
   "private": true,
   "main": "index.js",

--- a/packages/jest-presets/package.json
+++ b/packages/jest-presets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jest-presets",
+  "name": "@segment/jest-presets",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,8 +1434,8 @@ __metadata:
   dependencies:
     "@cloudflare/workers-types": ^3.16.0
     "@segment/edge-sdk": "*"
+    "@segment/eslint-config-edge-sdk": "*"
     "@segment/tsconfig-edge-sdk": "*"
-    eslint-config-edge-sdk: "*"
     typescript: ^4.8.3
     wrangler: 2.1.4
   languageName: unknown
@@ -1446,19 +1446,41 @@ __metadata:
   resolution: "@segment/edge-sdk@workspace:packages/edge-sdk"
   dependencies:
     "@cloudflare/workers-types": ^3.16.0
+    "@segment/eslint-config-edge-sdk": "*"
+    "@segment/jest-presets": "*"
     "@segment/snippet": ^4.15.3
     "@segment/tsconfig-edge-sdk": "*"
     "@types/jest": ^29.0.3
     "@types/uuid": ^8.3.4
     eslint: ^7.32.0
-    eslint-config-edge-sdk: "*"
     jest: ^29.0.3
-    jest-presets: "*"
     tldts: ^5.7.100
     tsup: ^5.10.1
     typescript: ^4.5.3
     uuid: ^9.0.0
     worktop: ^0.8.0-next.14
+  languageName: unknown
+  linkType: soft
+
+"@segment/eslint-config-edge-sdk@*, @segment/eslint-config-edge-sdk@workspace:packages/eslint-config-edge-sdk":
+  version: 0.0.0-use.local
+  resolution: "@segment/eslint-config-edge-sdk@workspace:packages/eslint-config-edge-sdk"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": ^5.49.0
+    "@typescript-eslint/parser": ^5.49.0
+    eslint: ^8.32.0
+    eslint-config-prettier: ^8.3.0
+    eslint-config-turbo: ^0.0.7
+  languageName: unknown
+  linkType: soft
+
+"@segment/jest-presets@*, @segment/jest-presets@workspace:packages/jest-presets":
+  version: 0.0.0-use.local
+  resolution: "@segment/jest-presets@workspace:packages/jest-presets"
+  dependencies:
+    jest-environment-miniflare: ^2.11.0
+    miniflare: ^2.11.0
+    ts-jest: ^29.0.1
   languageName: unknown
   linkType: soft
 
@@ -3342,18 +3364,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-edge-sdk@*, eslint-config-edge-sdk@workspace:packages/eslint-config-edge-sdk":
-  version: 0.0.0-use.local
-  resolution: "eslint-config-edge-sdk@workspace:packages/eslint-config-edge-sdk"
-  dependencies:
-    "@typescript-eslint/eslint-plugin": ^5.49.0
-    "@typescript-eslint/parser": ^5.49.0
-    eslint: ^8.32.0
-    eslint-config-prettier: ^8.3.0
-    eslint-config-turbo: ^0.0.7
-  languageName: unknown
-  linkType: soft
-
 "eslint-config-prettier@npm:^8.3.0":
   version: 8.6.0
   resolution: "eslint-config-prettier@npm:8.6.0"
@@ -4927,16 +4937,6 @@ __metadata:
   checksum: db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
   languageName: node
   linkType: hard
-
-"jest-presets@*, jest-presets@workspace:packages/jest-presets":
-  version: 0.0.0-use.local
-  resolution: "jest-presets@workspace:packages/jest-presets"
-  dependencies:
-    jest-environment-miniflare: ^2.11.0
-    miniflare: ^2.11.0
-    ts-jest: ^29.0.1
-  languageName: unknown
-  linkType: soft
 
 "jest-regex-util@npm:^29.4.3":
   version: 29.4.3
@@ -6535,7 +6535,7 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@changesets/cli": ^2.22.0
-    eslint-config-edge-sdk: "*"
+    "@segment/eslint-config-edge-sdk": "*"
     prettier: ^2.5.1
     turbo: latest
   languageName: unknown


### PR DESCRIPTION
- Add scope to packages to prevent accidental install of poisoned packages by developers
- Fix lint errors and ensure that CI catches them